### PR TITLE
Bug Fixed

### DIFF
--- a/virustotal-premium/operations.py
+++ b/virustotal-premium/operations.py
@@ -76,7 +76,7 @@ def check_payload(payload):
             nested = check_payload(value)
             if len(nested.keys()) > 0:
                 updated_payload[key] = nested
-        elif value:
+        elif value != '' and value is not None:
             updated_payload[key] = value
     return updated_payload
 

--- a/virustotal-premium/playbooks/playbooks.json
+++ b/virustotal-premium/playbooks/playbooks.json
@@ -1186,7 +1186,7 @@
                 "verdict": "{% if vars.last_analysis_stats.malicious > 0 %}{{\"Malicious\"}}{% elif vars.last_analysis_stats.suspicious > 0 %}{{\"Suspicious\"}}{% elif vars.last_analysis_stats.harmless > 0 %}{{\"Good\"}}{% else %}{{\"No Reputation Available\"}}{% endif %}",
                 "cti_name": "VirusTotal Premium",
                 "cti_score": "{{vars.last_analysis_stats.malicious or vars.last_analysis_stats.suspicious or 0}}",
-                "source_data": "{ \"VirusTotal\":{{vars.steps.Get_IP_Reputation.data}} }",
+                "source_data": "{ \"VirusTotal Premium\":{{vars.steps.Get_IP_Reputation.data}} }",
                 "field_mapping": "{ \"country\": {% if vars.steps.Get_IP_Reputation.data.attributes.country %}\"{{vars.steps.Get_IP_Reputation.data.attributes.country}}\"{% else %}{{None}}{% endif %}, \"asn\": {% if vars.steps.Get_IP_Reputation.data.attributes.asn %}{{vars.steps.Get_IP_Reputation.data.attributes.asn}}{% else %}{{None}}{% endif %}, \"as_owner\": {% if vars.steps.Get_IP_Reputation.data.attributes.as_owner %}\"{{vars.steps.Get_IP_Reputation.data.attributes.as_owner}}\"{% else %}{{None}}{% endif %}, \"regional_internet_registry\": {% if vars.steps.Get_IP_Reputation.data.attributes.regional_internet_registry %}\"{{vars.steps.Get_IP_Reputation.data.attributes.regional_internet_registry}}\"{% else %}{{None}}{% endif %}, \"last_modification_date\": {% if vars.steps.Get_IP_Reputation.data.attributes.last_modification_date %}{{vars.steps.Get_IP_Reputation.data.attributes.last_modification_date}}{% else %}{{None}}{% endif %} }",
                 "enrichment_summary": "{{vars.steps.Compute_VT_Summary.data['formatted_string']}}"
               },


### PR DESCRIPTION
#### Mantis:

- [0913607](https://mantis.fortinet.com/bug_view_page.php?bug_id=0913607) : Get Retrohunt Job List : When Limit field is set to zero , still we get the data in output
- [0913869](https://mantis.fortinet.com/bug_view_page.php?bug_id=0913869) : Get Retrohunt Job Matching Files: Gives data when limit is set to Zero
- [913960](https://mantis.fortinet.com/bug_update_ok.php?bug_id=913960) : For IP Address enrichment, VT Premium summary is not reflected in indicator's source data

#### UTCs:

- [x] Verified "Get Retrohunt Job List" and "Get Retrohunt Job Matching Files" operations.
- [x] Verified "IP Address > VirusTotal > Enrichment" playbook. 